### PR TITLE
Rasa diabelstwo (tiefling) wraz z mechaniką czarów rasowych

### DIFF
--- a/area/pomoc/pomoc-p.are
+++ b/area/pomoc/pomoc-p.are
@@ -1237,7 +1237,7 @@ umiej`etno`sci. Je`sli znajdujesz si`e w pomieszczeniu, w kt`orym mo`zna `cwiczy
 pokazywane s`a r`ownie`z umiej`etno`sci, kt`orych jeszcze nie znasz, ale mo`zesz
 teraz wy`cwiczy`c. Umiej`etno`sci oznaczone gwiazdk`a i rozja`snione to umiej`etno`sci
 wyuczone z ksi`ag, kt`orych nie mo`zesz rozwija`c inaczej ni`z poprzez u`zywanie.
-Umiej`etno`sci oznaczone plusem i rozja`snione to umiej`etno`sci do kt`orych dost`ep
+Umiej`etno`sci oznaczone plusem i rozja`snione to umiej`etno`sci, do kt`orych dost`ep
 zapewnia twoja rasa.
 
 `CWICZ z argumentem powoduje wy`cwiczenie podanej umiej`etno`sci/czaru. Stopie`n

--- a/area/pomoc/pomoc-p.are
+++ b/area/pomoc/pomoc-p.are
@@ -1237,6 +1237,8 @@ umiej`etno`sci. Je`sli znajdujesz si`e w pomieszczeniu, w kt`orym mo`zna `cwiczy
 pokazywane s`a r`ownie`z umiej`etno`sci, kt`orych jeszcze nie znasz, ale mo`zesz
 teraz wy`cwiczy`c. Umiej`etno`sci oznaczone gwiazdk`a i rozja`snione to umiej`etno`sci
 wyuczone z ksi`ag, kt`orych nie mo`zesz rozwija`c inaczej ni`z poprzez u`zywanie.
+Umiej`etno`sci oznaczone plusem i rozja`snione to umiej`etno`sci do kt`orych dost`ep
+zapewnia twoja rasa.
 
 `CWICZ z argumentem powoduje wy`cwiczenie podanej umiej`etno`sci/czaru. Stopie`n
 wyuczenia biegnie od 0% (nie wy`cwiczone) do 75%, a powy`zej tej granicy musisz

--- a/area/pomoc/pomoc-r.are
+++ b/area/pomoc/pomoc-r.are
@@ -571,6 +571,23 @@ nie wiadomo, jakie winy wypatrz`a u ciebie i kiedy zdecyduj`a pozbawi`c ziemski
 pad`o`l takiej zarazy jak ty!
 ~
 
+-1 DIABELSTWO DIABELSTWA~
+To niezwykle rzadka rasa ludzi z domieszk`a demoniej krwi. Diabelstwa sw`a postur`a
+przypominaj`a ludzkich przodk`ow, przy czym wyr`o`znia je czerwonawa sk`ora, ogon
+oraz rogi. Z natury s`a niegodziwe i dziedzicz`a sk`lonno`s`c do czynienia z`la,
+cho`c zdarzaj`a si`e wyj`atki.
+
+Diabelstwa preferuj`a diet`e zlo`zon`a z krwistego surowego mi`esa, cho`c przetworzone
+potrawy mi`esne r`ownie`z s`a dnia nich akceptowalne.
+
+Powy`zsze cechy sprawiaj`a, `ze inne rozumne rasy odnosz`a si`e do diabestw
+ze strachem i wrogo`sci`a.
+
+Diabelstwa s`a obdarzone naturaln`a zdolno`sci`a do widzenia w ciemno`sci oraz
+wzmo`zon`a odporno`sci`a przeciwko obra`zeniom oraz truciznom. Demoniczna krew daje
+im zdolno`s`c do otaczenia si`e ciemno`sci`a za pomoc`a czaru {?STREFA CIENIA{x.
+~
+
 0 $~
 
 #$

--- a/area/pomoc/pomoc-u.are
+++ b/area/pomoc/pomoc-u.are
@@ -2479,8 +2479,8 @@ b`edzie na widok nekromanty reagowa`lo strachem.
 0 "STREFA CIENIA"~
 Sk`ladnia: czaruj "strefa cienia"
 
-Nekromanta mo`ze roztoczy`c wok`o`l siebie mrok tak g`esty, `ze tylko postacie
-widz`ace w ciemno`sciach lub zaopatrzone w `swiat`lo b`ed`a w stanie co`s dojrze`c.
+Mo`zesz roztoczy`c wok`o`l siebie mrok tak g`esty, `ze tylko postacie widz`ace
+w ciemno`sciach lub zaopatrzone w `swiat`lo b`ed`a w stanie co`s dojrze`c.
 ~
 
 0 "STWORZENIE MUMII"~

--- a/src/act_info.c
+++ b/src/act_info.c
@@ -4156,7 +4156,7 @@ KOMENDA( do_practice )
 	{
 	    sn = tss->sn;
 
-	    if ( ch->pcdata->learned[ sn ] )
+	    if ( ch->pcdata->learned[ sn ] || ( ch->race == zr_diabelstwo && skill_table[ sn ].spell_fun == spell_strefa_cienia ) )
 	    {
 		if ( !bylo )
 		{
@@ -4178,6 +4178,12 @@ KOMENDA( do_practice )
 		}
 
 		if ( nie_ma
+		  && ch->pcdata->learned[ sn ] < 25 + 50 * ch->level / 100
+		  && ch->race == zr_diabelstwo && skill_table[ sn ].spell_fun == spell_strefa_cienia )
+		    sprintf( buf, "{W%s+ %3d%%{x",
+			wyrownaj( skill_table[ sn ].pl_name, 19 ),
+			UMAX( ch->pcdata->learned[ sn ], 25 + 50 * ch->level / 100 ) );
+		else if ( nie_ma
 		  && ch->level < skill_table[ sn ].skill_level[ ch->klasa ] )
 		    sprintf( buf, "{W%s* %3d%%{x",
 			wyrownaj( skill_table[ sn ].pl_name, 19 ),

--- a/src/const.c
+++ b/src/const.c
@@ -490,7 +490,7 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	ODD_POWIETRZEM, POR_LAD,
 	4, 320, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, "pi`e`s`c", 2,
-	"Githyanki Vampire Werewolf Mindflayer",
+	"Githyanki Vampire Werewolf Mindflayer Tiefling",
 	"", "",
 	WRL_HS, PAPU_DOWOLNE,
 	P_HS, 0
@@ -503,7 +503,7 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	ODD_POWIETRZEM, POR_LAD,
 	4, 240, -2, 3, 2, 1, -2,
 	0, 4, 0, 0, 0, "pi`e`s`c", 2,
-	"Drow Ogre Orc Kobold Troll Hobgoblin Dragon Vampire Werewolf Goblin Halfkobold Duergar",
+	"Drow Ogre Orc Kobold Troll Hobgoblin Dragon Vampire Werewolf Goblin Halfkobold Duergar Tiefling",
 	"", "",
 	WRL_HS, PAPU_DOWOLNE,
 	P_HS, 0
@@ -515,7 +515,7 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	ODD_POWIETRZEM, POR_LAD,
 	4, 280, 0, 2, 1, 0, -1,
 	0, 2, 0, 0, 0, "pi`e`s`c", 2,
-	"Drow Ogre Orc Kobold Troll Hobgoblin Dragon Vampire Werewolf Goblin Duergar",
+	"Drow Ogre Orc Kobold Troll Hobgoblin Dragon Vampire Werewolf Goblin Duergar Tiefling",
 	"", "",
 	WRL_HS, PAPU_DOWOLNE,
 	P_HS, 0
@@ -528,7 +528,7 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	ODD_POWIETRZEM, POR_LAD,
 	4, 240, -1, 1, 2, 1, 0,
 	0, 4, 0, 0, 0, "pi`e`s`c", 2,
-	"Elf Halfelf Hobbit Githyanki Vampire Werewolf Duergar",
+	"Elf Halfelf Hobbit Githyanki Vampire Werewolf Duergar Tiefling",
 	"", "",
 	WRL_HS, PAPU_DOWOLNE,
 	P_HS, 0
@@ -541,7 +541,7 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	ODD_POWIETRZEM, POR_LAD,
 	3, 320, 2, 0, 0, -1, 1,
 	0, 0, 0, 0, 1, "pi`e`s`c", 2,
-	"Giant Ogre Orc Kobold Minotaur Troll Hobgoblin Dragon Vampire Werewolf Goblin Halfkobold",
+	"Giant Ogre Orc Kobold Minotaur Troll Hobgoblin Dragon Vampire Werewolf Goblin Halfkobold Tiefling",
 	"", "",
 	WRL_HS, PAPU_DOWOLNE,
 	P_HS, 0
@@ -553,7 +553,7 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	ODD_POWIETRZEM, POR_LAD,
 	3, 320, 1, 0, 0, 0, 1,
 	0, 0, 0, 0, 0, "pi`e`s`c", 2,
-	"Giant Ogre Orc Kobold Minotaur Troll Hobgoblin Dragon Vampire Werewolf Goblin",
+	"Giant Ogre Orc Kobold Minotaur Troll Hobgoblin Dragon Vampire Werewolf Goblin Tiefling",
 	"", "",
 	WRL_HS, PAPU_DOWOLNE,
 	P_HS, 0
@@ -566,7 +566,7 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	ODD_POWIETRZEM, POR_LAD,
 	3, 240, 0, 1, 0, 3, -1,
 	0, 0, 0, 0, 0, "pi`e`s`c", 2,
-	"Giant Ogre Orc Kobold Minotaur Troll Hobgoblin Dragon Vampire Werewolf Goblin Halfkobold",
+	"Giant Ogre Orc Kobold Minotaur Troll Hobgoblin Dragon Vampire Werewolf Goblin Halfkobold Tiefling",
 	"", "",
 	WRL_STOPY, PAPU_DOWOLNE,
 	P_HS, 0
@@ -578,7 +578,7 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	ODD_POWIETRZEM, POR_LAD,
 	3, 240, -1, 1, 1, 2, -1,
 	0, 4, 0, 0, 0, "pi`e`s`c", 2,
-	"Drow Ogre Orc Kobold Troll Hobgoblin Dragon Vampire Werewolf Goblin Duergar",
+	"Drow Ogre Orc Kobold Troll Hobgoblin Dragon Vampire Werewolf Goblin Duergar Tiefling",
 	"", "",
 	WRL_HS, PAPU_DOWOLNE,
 	P_HS, 0
@@ -922,6 +922,19 @@ const	struct	  race_type	  race_table	  [ MAX_RACE ]	  =
 	"", "",
 	WRL_HS, PAPU_WSZYSTKO | PAPU_MIESNE | PAPU_RYBNE,
 	P_FLAKI | P_GLOWA | P_RECE | P_NOGI | P_SERCE | P_JEZYK | P_ZAB, 0
+    },
+
+    { "diabelstwo", "diabelstwa", "diabelstwu", "diabelstwo", "diabelstwem",
+	"diabelstwie", "diabelstwo", "diabelstwo", "tiefling",
+	RACE_INFRAVISION | RACE_WEAPON_WIELD | RACE_OPENS_DOORS
+	 | RACE_PROTECTION | RACE_POISONIMM | RACE_CASTER,
+	ODD_POWIETRZEM, POR_LAD,
+	4, 320, -1, 2, 0, 0, 0,
+	0, 4, 0, 0, 0, "pi`e`s`c", 2,
+	"Githyanki Vampire Werewolf Mindflayer",
+	"", "",
+	WRL_GLOWA, PAPU_MIESNE,
+	P_HS | P_OGON | P_ROG, &zr_diabelstwo
     },
 
     { "przedmiot", "przedmiotu", "przedmiotowi", "przedmiot", "przedmiotem",

--- a/src/db.c
+++ b/src/db.c
@@ -357,6 +357,7 @@ int	gsn_teleport;
  */
 int	zr_bog;
 int	zr_byk;
+int	zr_diabelstwo;
 int	zr_harpia;
 int	zr_jednorozec;
 int	zr_jez;

--- a/src/magic.c
+++ b/src/magic.c
@@ -225,8 +225,10 @@ KOMENDA( do_cast )
     char       arg2[ MAX_INPUT_LENGTH ];
     int        mana;
     int        sn;
+    int        learned;
 
-    if ( !IS_NPC( ch ) && !class_table[ ch->klasa ].fMana && ch->level < L_APP )
+    if ( !IS_NPC( ch ) && !class_table[ ch->klasa ].fMana
+      && ch->level < L_APP && !IS_SET( race_table[ ch->race ].race_abilities, RACE_CASTER ) )
     {
 	send_to_char( "Nie znasz si`e na czarowaniu.\n\r", ch );
 	return;
@@ -244,6 +246,11 @@ KOMENDA( do_cast )
 	return;
     }
 
+    sn = skill_lookup_pl( arg1 );
+    learned = UMAX(
+	!IS_NPC( ch ) ? ch->pcdata->learned[ sn ] : 0,
+	ch->race == zr_diabelstwo && skill_table[ sn ].spell_fun == spell_strefa_cienia ? 25 + 50 * ch->level / 100 : 0 );
+
 	 /* Lam: zabezpieczenie przed reserved: */
     if ( ( sn = skill_lookup_pl( arg1 ) ) < 1
 	|| !skill_table[ sn ].spell_fun /* to umiejetnosc, a nie czar */
@@ -251,7 +258,7 @@ KOMENDA( do_cast )
 	|| ( !IS_NPC( ch )
 	  && ch->level < skill_table[ sn ].skill_level[ ch->klasa ]
 	  && ch->level < skill_table[ sn ].multi_level[ ch->klasa ]
-	  && !ch->pcdata->learned[ sn ] ) )
+	  && !learned ) )
     {
 	send_to_char( "Nie mo`zesz tego zrobi`c.\n\r", ch );
 	return;
@@ -260,7 +267,7 @@ KOMENDA( do_cast )
     if ( !IS_NPC( ch )
       && ch->level < skill_table[ sn ].skill_level[ ch->klasa ]
       && !ma_w_multi( ch, sn )
-      && !ch->pcdata->learned[ sn ] )
+      && !learned )
     {
 	send_to_char( "Nie mo`zesz tego zrobi`c.\n\r", ch );
 	return;
@@ -442,7 +449,7 @@ KOMENDA( do_cast )
     target_name = argument;
 
     if ( !IS_NPC( ch )
-      && ( number_percent( ) > ch->pcdata->learned[ sn ]
+      && ( number_percent( ) > learned
 	|| ( IS_AFFECTED( ch, AFF_DEZORIENTACJA )
 	  && number_percent( ) > 80 ) ) )
     {

--- a/src/merc.h
+++ b/src/merc.h
@@ -1402,6 +1402,7 @@ struct czesc_ciala
 #define RACE_BEZ_WECHU			b23	/* Lam */
 #define RACE_WOLI_LATAC			b24	/* Lam */
 #define RACE_WOLI_PLYWAC		b25	/* Lam */
+#define RACE_CASTER			b26	/* Ulryk: przedstawiciele rasy potrafia czarowac */
 
 /* oddychanie */
 #define ODD_POWIETRZEM			b01
@@ -2989,6 +2990,12 @@ extern	int	gsn_swiety_msciciel;
  */
 extern	int	zr_bog;
 extern	int	zr_byk;
+/*
+ * W przypadku rozpowszechnienia wsparcia dla czarow rasowych
+ * nalezy uwzglednic dedykowana strukture w race_type
+ * Ulryk 28.02.25
+ */
+extern	int	zr_diabelstwo;
 extern	int	zr_harpia;
 extern	int	zr_jednorozec;
 extern	int	zr_jez;

--- a/src/update.c
+++ b/src/update.c
@@ -296,7 +296,7 @@ void uzyj( CHAR_DATA *ch, int sn, const char *co )
     if ( IS_NPC( ch ) )
 	return;
 
-    if ( ch->pcdata->learned[ sn ] >= 100 )
+    if ( !ch->pcdata->learned[ sn ] || ch->pcdata->learned[ sn ] >= 100 )
 	return;
 
     ++ch->pcdata->used[ sn ];


### PR DESCRIPTION
Rasa bazująca na bestiariuszu D&D:
- https://dnd5e.wikidot.com/lineage:tiefling
- https://sfery.fandom.com/wiki/Diabelstwo

W D&D rasa ma wrodzoną umiejętność rzucania czaru "ciemność". Lac ma [strefę cienia](http://kto.lac.pl:3999/pomoc?p=strefa+cienia), więc odwzorowałem tą cechę w postaci nowej mechaniki - czaru rasowego.

Rasa dostała nową flagę `RACE_CASTER` pozwalającą na używanie `do_cast` nawet klasom nieczarującym oraz wsparcie dla rzucania tego jednego czaru dla tej jednej rasy. Jeśli wsparcie dla czarów rasowych miałoby być powszechniej stosowane, to trzeba będzie to oprzeć o rozszerzenie w `race_type`.

Poza oczywistymi miejscami zmiany objęły w szczególności:
- act_info.c: prezentację umiejętności rasowej na liście w `do_practice` - jeśli postać ma dostęp do czaru dzięki rasie, to umiejętność na liście jest oznaczona symbolem "+"
- magic.c: zmiany w `do_cast`:
  - możliwość rzucania czaru przez rasę z flagą `RACE_CASTER`
  - stopień znajomości czaru używany w formułach podmieniony, na wyliczany, jako maksimum ze znajomości umiejętności wyćwiczonej oraz formuły zależnej od poziomu dla umiejętności rasowej
- update.c: zablokowanie możliwości nauczenia się czaru, poprzez używanie umiejętności rasowej 

Do zastanowienia danie tej rasie w przyszłości flagi `RACE_PC_AVAIL`.